### PR TITLE
Fix encoder_hidden_states in inpaint pipeline

### DIFF
--- a/pipeline_stable_diffusion_xl_instantid_inpaint.py
+++ b/pipeline_stable_diffusion_xl_instantid_inpaint.py
@@ -578,7 +578,7 @@ class StableDiffusionXLInstantIDInpaintPipeline(StableDiffusionXLControlNetInpai
                 noise_pred = self.unet(
                     latent_model_input,
                     t,
-                    encoder_hidden_states=prompt_embeds,
+                    encoder_hidden_states=encoder_hidden_states,
                     cross_attention_kwargs=self.cross_attention_kwargs,
                     down_block_additional_residuals=down_block_res_samples,
                     mid_block_additional_residual=mid_block_res_sample,


### PR DESCRIPTION
Fix bug in #5 

```python
...
encoder_hidden_states = torch.cat([prompt_embeds, prompt_image_emb], dim=1) # L494 in code
...
noise_pred = self.unet(
    latent_model_input, 
    t, 
    encoder_hidden_states=encoder_hideen_states, ##################### Fix
    cross_attention_kwargs=self.cross_attention_kwargs,   
    down_block_additional_residuals=down_block_res_samples, 
    mid_block_additional_residual=mid_block_res_sample, 
    added_cond_kwargs=added_cond_kwargs, 
    return_dict=False,
)[0]
```